### PR TITLE
과제 추가시 텍스트/자료 선택기능 추가

### DIFF
--- a/src/main/java/itda/ieoso/Assignment/Assignment.java
+++ b/src/main/java/itda/ieoso/Assignment/Assignment.java
@@ -34,6 +34,16 @@ public class Assignment {
     @Column(length = 1000)
     private String assignmentDescription;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SubmissionType submissionType;
+
+    public enum SubmissionType {
+        TEXT,
+        FILE,
+        BOTH;
+    }
+
     private LocalDateTime startDate;
     private LocalDateTime endDate;
 
@@ -74,5 +84,9 @@ public class Assignment {
 
     public void setUpdatedAt(LocalDateTime updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public void setSubmissionType(SubmissionType submissionType) {
+        this.submissionType = submissionType;
     }
 }

--- a/src/main/java/itda/ieoso/Assignment/AssignmentDTO.java
+++ b/src/main/java/itda/ieoso/Assignment/AssignmentDTO.java
@@ -1,5 +1,6 @@
 package itda.ieoso.Assignment;
 
+import itda.ieoso.Assignment.Assignment.SubmissionType;
 import itda.ieoso.ContentOrder.ContentOrder;
 import itda.ieoso.Submission.SubmissionStatus;
 import itda.ieoso.Video.Video;
@@ -18,6 +19,7 @@ public class AssignmentDTO {
             String assignmentTitle,
             String assignmentDescription,
             // LocalDateTime startDate,
+            SubmissionType submissionType,
             LocalDateTime endDate
 
     ) {}
@@ -26,6 +28,7 @@ public class AssignmentDTO {
             Long assignmentId,
             String assignmentTitle,
             String assignmentDescription,
+            SubmissionType submissionType,
             LocalDateTime startDate,
             LocalDateTime endDate,
             Long contentOrderId,
@@ -37,6 +40,7 @@ public class AssignmentDTO {
                     assignment.getAssignmentId(),
                     assignment.getAssignmentTitle(),
                     assignment.getAssignmentDescription(),
+                    assignment.getSubmissionType(),
                     assignment.getStartDate(),
                     assignment.getEndDate(),
                     null,
@@ -50,6 +54,7 @@ public class AssignmentDTO {
                     assignment.getAssignmentId(),
                     assignment.getAssignmentTitle(),
                     assignment.getAssignmentDescription(),
+                    assignment.getSubmissionType(),
                     assignment.getStartDate(),
                     assignment.getEndDate(),
                     contentOrder.getContentOrderId(),

--- a/src/main/java/itda/ieoso/Assignment/AssignmentService.java
+++ b/src/main/java/itda/ieoso/Assignment/AssignmentService.java
@@ -32,6 +32,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static itda.ieoso.Assignment.Assignment.*;
+
 @Service
 @RequiredArgsConstructor
 public class AssignmentService {
@@ -70,11 +72,12 @@ public class AssignmentService {
         }
 
         // assignment 생성
-        Assignment assignment = Assignment.builder()
+        Assignment assignment = builder()
                 .course(course)
                 .lecture(lecture)
                 .assignmentTitle(null)
                 .assignmentDescription(null)
+                .submissionType(SubmissionType.TEXT)
                 .startDate(LocalDateTime.of(course.getStartDate(), LocalTime.of(0, 0, 0)))
                 .endDate(null)
                 .createdAt(LocalDateTime.now())
@@ -124,8 +127,10 @@ public class AssignmentService {
 //        }
 
         // assignment 수정
+        // TODO submssionType추가
         if (request.assignmentTitle()!=null) assignment.setAssignmentTitle(request.assignmentTitle());
         if (request.assignmentDescription()!=null) assignment.setAssignmentDescription(request.assignmentDescription());
+        if (request.submissionType()!=null) assignment.setSubmissionType(request.submissionType());
         // if (request.startDate()!=null) assignment.setStartDate(request.startDate());
         if (request.endDate()!=null) assignment.setEndDate(request.endDate());
         assignment.setUpdatedAt(LocalDateTime.now());

--- a/src/main/java/itda/ieoso/Course/CourseService.java
+++ b/src/main/java/itda/ieoso/Course/CourseService.java
@@ -327,6 +327,7 @@ public class CourseService {
                 .lecture(lecture)
                 .assignmentTitle("과제 제목을 입력하세요.")
                 .assignmentDescription(null)
+                .submissionType(Assignment.SubmissionType.TEXT)
                 .startDate(LocalDateTime.of(course.getStartDate(),LocalTime.of(0, 0, 0))) // 강좌시작일
                 .endDate(LocalDateTime.of(endDate, assignmentDueTime.toLocalTime()))
                 .createdAt(LocalDateTime.now())

--- a/src/main/java/itda/ieoso/Submission/SubmissionService.java
+++ b/src/main/java/itda/ieoso/Submission/SubmissionService.java
@@ -63,6 +63,8 @@ public class SubmissionService {
             throw new CustomException(ErrorCode.SUBMISSION_PERMISSION_DENIED);
         }
 
+        // TODO assignment의 submissionType에 따라 제출방식 제한
+
         //기존 파일 유지 (existingFileUrls에 포함된 파일만 유지)
         if (existingFileUrls != null) {
             submission.setSubmissionFiles(


### PR DESCRIPTION
## Issue Number
#86 

## 요약(Summary)
- assignment 도메인에 submissionType추가 (FILE,TEXT,BOTH / default = TEXT)
- assignment crud 수정
- assignmentDto 수정
- 초기설정시 과제생성기능 수정
## PR 유형
- [ ] 새로운 기능 추가

## 공유사항(to 리뷰어)
assignment에 type만 추가했는데, 추후에는 submission 제출시 타입과 일치하지않으면 제출되지 못하도록 
추가하는게 어떨까 싶습니당