### PR TITLE
fix: user 도메인에 email unique제약조건 추가

### DIFF
--- a/src/main/java/itda/ieoso/User/User.java
+++ b/src/main/java/itda/ieoso/User/User.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.UniqueElements;
 
 @Entity(name = "users")
 @Getter
@@ -17,7 +18,7 @@ public class User {
     @Column(name = "user_id")
     private Long userId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String email;
 
     @Column(nullable = false)


### PR DESCRIPTION
## Issue Number
#122 

## 요약(Summary)
email중복 검증을 뚫고 생기는 중복된 이메일을 방지하기위해 unique제약조건 추가

## PR 유형
- [ ] 버그 수정

## 공유사항(to 리뷰어)

